### PR TITLE
Fix publishing of Relational Artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ atlassian-ide-plugin.xml
 protogen/
 /protogen/
 */protogen/*
-*/gen/*
+**/gen/*
 
 *.orig
 /.classpath*

--- a/build.gradle
+++ b/build.gradle
@@ -128,8 +128,8 @@ allprojects {
     task sourcesJar(type: Jar, dependsOn: 'compileJava') {
         description = "Assembles a Jar archive containing the main sources."
         group = JavaBasePlugin.DOCUMENTATION_GROUP
-        appendix = null
-        classifier = "sources"
+        archiveAppendix = null
+        archiveClassifier = "sources"
         from sourceSets.main.allSource
     }
 
@@ -137,8 +137,8 @@ allprojects {
     task javadocJar(type: Jar) {
         description = "Assembles a Jar archive containing the main Javadoc."
         group = JavaBasePlugin.DOCUMENTATION_GROUP
-        appendix = null
-        classifier = "javadoc"
+        archiveAppendix = null
+        archiveClassifier = "javadoc"
         from tasks.javadoc
     }
 

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -29,7 +29,7 @@ dependencies {
 }
 
 shadowJar {
-    classifier = null
+    setArchiveClassifier(null)
     relocate 'com.google', 'com.apple.foundationdb.record.shaded.com.google'
     dependencies {
         include(dependency(coreProject))
@@ -48,8 +48,8 @@ createDistribution {dependsOn('shadowJar')}
 task shadedSourcesJar(type: Jar) {
     description = "Assembles a Jar archive containing the main sources."
     group = JavaBasePlugin.DOCUMENTATION_GROUP
-    appendix = null
-    classifier = "sources"
+    setArchiveAppendix(null)
+    setArchiveClassifier("sources")
     from project(coreProject).sourceSets.main.allSource
     from project(':fdb-extensions').sourceSets.main.allSource
 }
@@ -81,6 +81,8 @@ def addDependencies(projectObj, dependenciesNode) {
 
 apply from: rootProject.file('gradle/publishing.gradle')
 publishing {
+    publications.remove(publishing.publications.library)
+
     publications {
         shadow(MavenPublication) { publication ->
             from project.shadow.component(publication)

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -48,8 +48,8 @@ createDistribution {dependsOn('shadowJar')}
 task shadedSourcesJar(type: Jar) {
     description = "Assembles a Jar archive containing the main sources."
     group = JavaBasePlugin.DOCUMENTATION_GROUP
-    setArchiveAppendix(null)
-    setArchiveClassifier("sources")
+    archiveAppendix = null
+    archiveClassifier = "sources"
     from project(coreProject).sourceSets.main.allSource
     from project(':fdb-extensions').sourceSets.main.allSource
 }
@@ -57,8 +57,8 @@ task shadedSourcesJar(type: Jar) {
 task shadedJavadocJar(type: Jar) {
     description = "Assembles a Jar archive containing the main Javadoc."
     group = JavaBasePlugin.DOCUMENTATION_GROUP
-    appendix = null
-    classifier = "javadoc"
+    archiveAppendix = null
+    archiveClassifier = "javadoc"
     from project(coreProject).tasks.javadoc
 }
 
@@ -80,6 +80,7 @@ def addDependencies(projectObj, dependenciesNode) {
 }
 
 apply from: rootProject.file('gradle/publishing.gradle')
+
 publishing {
     publications.remove(publishing.publications.library)
 

--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -65,7 +65,7 @@ sourceSets {
 }
 
 task testShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-    classifier = 'standalone-tests'
+    archiveClassifier = 'standalone-tests'
     from sourceSets.main.output
     from sourceSets.test.output
     configurations = [ project.configurations.testRuntimeOnly ]
@@ -79,7 +79,7 @@ task testShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.Shadow
 }
 
 task replJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-    classifier = 'repl'
+    archiveClassifier = 'repl'
     from sourceSets.main.output
     from sourceSets.test.output
     configurations = [ project.configurations.repl ]

--- a/fdb-relational-api/fdb-relational-api.gradle
+++ b/fdb-relational-api/fdb-relational-api.gradle
@@ -64,7 +64,6 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
 
     testFixturesImplementation "org.assertj:assertj-core:${assertjVersion}"
-    testFixturesImplementation "com.google.protobuf:protobuf-java:${protobufVersion}"
 }
 
 sourceSets {

--- a/fdb-relational-cli/fdb-relational-cli.gradle
+++ b/fdb-relational-cli/fdb-relational-cli.gradle
@@ -22,8 +22,6 @@ plugins {
     id 'application'
 }
 
-description = 'FDB Relational CLI (Connects to FDB Relational Layer via JDBC)'
-
 apply from: rootProject.file('gradle/publishing.gradle')
 apply from: rootProject.file('gradle/antlr.gradle')
 
@@ -132,4 +130,14 @@ distTar {
     dependsOn "javadoc"
     compression = Compression.GZIP
     archiveExtension = "tar.gz"
+}
+
+publishing {
+    publications {
+        library(MavenPublication) {
+            pom {
+                description = 'Relational CLI (Connects to FDB Relational Layer via JDBC)'
+            }
+        }
+    }
 }

--- a/fdb-relational-grpc/fdb-relational-grpc.gradle
+++ b/fdb-relational-grpc/fdb-relational-grpc.gradle
@@ -21,11 +21,10 @@
 apply from: rootProject.file('gradle/proto.gradle')
 apply from: rootProject.file('gradle/publishing.gradle')
 
-description = "Relational GRPC client/server protos and generated code. \
-Keep the generated protobufs in their own module so clients and servers \
-can mix-in grpc dependencies independently without having to pull in \
-unrelated concerns. In particular, we do not want client jars bundling \
-server-side code or dependencies."
+// Keep the generated protobufs in their own module so clients and servers \
+// can mix-in grpc dependencies independently without having to pull in \
+// unrelated concerns. In particular, we do not want client jars bundling \
+// server-side code or dependencies."
 
 // From https://github.com/google/protobuf-gradle-plugin
 protobuf {
@@ -76,4 +75,14 @@ dependencies {
 javadoc {
     source = sourceSets.main.allJava
     exclude '**/grpc/**'
+}
+
+publishing {
+    publications {
+        library(MavenPublication) {
+            pom {
+                description = 'Relational gRPC client/server protos and generated code.'
+            }
+        }
+    }
 }

--- a/fdb-relational-jdbc/fdb-relational-jdbc.gradle
+++ b/fdb-relational-jdbc/fdb-relational-jdbc.gradle
@@ -23,7 +23,6 @@ plugins {
     id 'com.github.johnrengelman.shadow' version "${shadowPluginVersion}"
 }
 
-description = 'The Relational JDBC Driver; has no FDB nor Record Layer dependencies.'
 
 apply from: rootProject.file('gradle/publishing.gradle')
 
@@ -78,10 +77,10 @@ createDistribution.configure {
 
 publishing {
     publications {
-        // Note: in new versions this changes, see docs:
-        // https://gradleup.com/shadow/publishing/#publishing-with-maven-publish-plugin
-        shadow(MavenPublication) { publication ->
-            from project.shadow.component(publication)
+        library(MavenPublication) {
+            pom {
+                description = 'JDBC Driver for FDB Relational.'
+            }
         }
     }
 }

--- a/fdb-relational-server/fdb-relational-server.gradle
+++ b/fdb-relational-server/fdb-relational-server.gradle
@@ -26,8 +26,6 @@ plugins {
 
 apply from: rootProject.file('gradle/publishing.gradle')
 
-description = 'Relational Layer Server.'
-
 // Don't build a zip assembly, just the tar one.
 tasks.distZip.enabled = false
 build.dependsOn installDist
@@ -74,10 +72,10 @@ createDistribution.configure {
 
 publishing {
     publications {
-        // Note: in new versions this changes, see docs:
-        // https://gradleup.com/shadow/publishing/#publishing-with-maven-publish-plugin
-        shadow(MavenPublication) { publication ->
-            from project.shadow.component(publication)
+        library {
+            pom {
+                description = 'Relational Layer server'
+            }
         }
     }
 }

--- a/fdb-relational-server/src/main/resources/log4j2.xml
+++ b/fdb-relational-server/src/main/resources/log4j2.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  log4j2.xml
 
@@ -18,7 +19,6 @@
  limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -58,7 +58,7 @@ publishing {
             from components.java
 
             // Test fixtures appear to be placing their dependencies in the wrong scope
-            // for maven compilation, which means that their dependencies wing up in the
+            // for maven compilation, which means that their dependencies wind up in the
             // final project's pom.xml.
             // See: https://github.com/gradle/gradle/issues/14936
             // Until this is fixed, skip these configurations to avoid polluting the list of dependencies

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -56,6 +56,20 @@ publishing {
     publications {
         library(MavenPublication) { publication ->
             from components.java
+
+            // Test fixtures appear to be placing their dependencies in the wrong scope
+            // for maven compilation, which means that their dependencies wing up in the
+            // final project's pom.xml.
+            // See: https://github.com/gradle/gradle/issues/14936
+            // Until this is fixed, skip these configurations to avoid polluting the list of dependencies
+            configurations.each { config ->
+                if (config.name == 'testFixturesApiElements' || config.name == 'testFixturesRuntimeElements') {
+                    components.java.withVariantsFromConfiguration(config) {
+                        skip()
+                    }
+                }
+            }
+
             artifact tasks.sourcesJar
             artifact tasks.javadocJar
             artifact tasks.testJar

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -234,7 +234,7 @@ tasks.withType(Test).configureEach { task ->
 task testJar(type: Jar, dependsOn: testClasses) {
     group = 'Build'
     description = 'Build a jar file of test classes as an exported artifact'
-    classifier='test'
+    archiveClassifier = 'test'
     from sourceSets.test.output
 }
 

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -69,7 +69,58 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
 }
 
+ext.resolveOtherServer = { ->
+    def configurationName = "resolveArtifact-${UUID.randomUUID()}"
+    return rootProject.with {
+        configurations.create(configurationName, {
+            resolutionStrategy {
+                failOnChangingVersions()
+                // Note: In the root of the project we set cacheChangingModulesFor and cacheDynamicVersionFor to 0
+                // We explicitly change that for changing modules, because we should reject those anyways.
+                cacheChangingModulesFor 1000, "days" // TTL for snapshots
+            }
+        })
+        // I tried setting the version to 'latest.release', but that causes it to download all of the snapshots
+        // every time you execute. This is because `latest.release` becomes `LatestVersionSelector` which
+        // `requiresMetadata`, because it looks at the metadata for the module to determine if it is a release.
+        // I also tried just setting it to `+`, but that causes it to fetch the latest snapshot, which isn't exactly
+        // what we want.
+        dependencies.add(configurationName,
+                ['group': 'org.foundationdb',
+                 'name': 'fdb-relational-server',
+                 'version': '3.5-SNAPSHOT', // todo: will have to set to a known version once a build is published
+                 // the all classifier specifies that we want to fetch the shadow jar, which includes all the
+                 // dependencies
+                 'classifier': 'all'],
+                {
+                    // we don't want to take in any transitive dependencies.
+                    // There shouldn't be any external dependencies, but commenting this out, this fails with a missing
+                    // grpc dependency.
+                    transitive=false
+                    changing=true
+                })
+        def configuration = configurations.getByName(configurationName, { })
+
+        def resolution = configuration.resolve()[0]
+        System.out.println("Downloaded old external server: " + resolution.getName())
+        return resolution
+    }
+}
+
+task cleanExternalServerDirectory(type: Delete) {
+    delete project.layout.buildDirectory.dir('externalServer')
+}
+
+task downloadExternalServer(type: Copy) {
+    dependsOn "cleanExternalServerDirectory"
+    // todo: will be able to uncomment once other server has been published
+    // from resolveOtherServer()
+    into project.layout.buildDirectory.dir('externalServer')
+}
+
 test {
+    dependsOn "downloadExternalServer"
+    systemProperty("yaml_testing_external_server", project.layout.buildDirectory.dir('externalServer').get().asFile)
     // These are the system properties that are looked at by the YamlTesting framework to initialize the execution context
     var isNightly = System.getenv("COM_APPLE_FOUNDATIONDB_RELATIONAL_YAMLTESTS_NIGHTLY")
     if (isNightly != null) {

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -34,10 +34,6 @@ tasks.named("sourcesJar") {
     from sourceSets.main.allSource
 }
 
-java {
-    withSourcesJar()
-}
-
 apply from: rootProject.file('gradle/publishing.gradle')
 
 configurations {
@@ -94,5 +90,15 @@ test {
         systemProperty("yaml_testing_nightly_repetition", Integer.parseInt(nightlyRepetitions))
     } else {
         systemProperty("yaml_testing_nightly_repetition", 100)
+    }
+}
+
+publishing {
+    publications {
+        library(MavenPublication) {
+            pom {
+                description = 'Tests of the Relational project driven off of YAML specifications.'
+            }
+        }
     }
 }


### PR DESCRIPTION
Updates the publishing process for relational subprojects. I've validated that this produces sensible artifacts when pushed to maven local. That is, the `pom.xml` files have correct descriptions and dependency lists that appear to contain all of the correct items. This also adds the beginnings of a feature to the yaml tests to allow for downloading a previous version of the `fdb-relational-server`, though it requires a fixed version number be already present (which isn't true for the maven setups).